### PR TITLE
Include acb.h (necessary for building with FLINT 3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -504,7 +504,8 @@ AS_IF([test "x$with_arblib_ldflags" == "x"],
 )
 AC_MSG_RESULT([$arblib_ldflags])
 GYOTO_ARG_LIB(arblib, arblib, $arblib_ldflags,
-	      [#include <acb_hypgeom.h>],
+	      [#include <acb.h>
+	       #include <acb_hypgeom.h>],
 	      [double hypergeom = 0., rad=0., kappaIndex=5., thetae=1;
   	 acb_t FF, aa, bb, cc, zed;
 	 acb_init(FF);

--- a/lib/Utils.C
+++ b/lib/Utils.C
@@ -44,6 +44,7 @@ static int gyoto_prev_verbosity=GYOTO_DEBUG_VERBOSITY;
 #endif
 
 #if defined GYOTO_USE_ARBLIB
+# include <acb.h>
 # include <acb_hypgeom.h>
 #elif defined GYOTO_USE_AEAE
 # include <complex>


### PR DESCRIPTION
Arb was merged into FLINT beginning with FLINT 3.  One of the changes is that `acb_hypgeom.h` no longer includes `acb.h`, so it must be included explicitly.  This makes it possible to build Gyoto against FLINT3 by passing the right `--with-arblib-*` options to `configure`. 

In particular, after this change I was able to get Gyoto to build against FLINT 3 in Debian unstable using `--with-arblib-ldflags=-lflint`, `--with-arblib-headers=/usr/include/flint`, and `--with-arblib-libs=/usr/lib`.